### PR TITLE
PHP version support upgrade

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,11 +12,11 @@
         }
     ],
     "require": {
-        "php": "^5.4|^7.0|^8.0"
+        "php": "^7.3|^8.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.6",
-        "phpunit/phpunit": "^11.1",
+        "phpunit/phpunit": "^9.0",
         "guzzlehttp/guzzle": "^7.8"
     },
     "autoload": {


### PR DESCRIPTION
* Removed PHP 5.4 support
* Downgraded to phpunit 9.0 for highest supported PHP ver
* Increased minimum required PHP ver to 7.3